### PR TITLE
Implement openai config for telegram bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Summary Tasks Bot
+
+This example project demonstrates a simple Telegram bot with pluggable storage.
+It is intentionally minimal and uses only the standard library.
+
+## Usage
+
+The bot understands the following commands:
+
+* `/start` – start receiving periodic updates about default topics.
+* `/update_topics <topic1> <topic2>` – change the topics you are interested in.
+* `/stop` – stop receiving updates.
+
+User settings are stored in a JSON file specified via the `SETTINGS_FILE` environment variable.
+
+### Running
+
+Set the following environment variables before running the bot:
+
+* `TELEGRAM_TOKEN` – your Telegram bot token (required)
+* `OPENAI_TOKEN` – OpenAI API token (optional, enables news generation using OpenAI)
+* `SETTINGS_FILE` – path to the JSON file for storing user settings (defaults to `settings.json`)
+
+Then start the bot with:
+
+```bash
+go run ./cmd/bot
+```
+
+The bot periodically sends messages based on stored user preferences.

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/example/summary-tasks-bot/internal/app"
+	"github.com/example/summary-tasks-bot/internal/config"
+	"github.com/example/summary-tasks-bot/internal/repository"
+)
+
+func main() {
+	cfg, err := config.FromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	repo, err := repository.NewFileUserSettingsRepository(cfg.SettingsPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	application := app.New(cfg.TelegramToken, cfg.OpenAIToken, repo)
+	if err := application.Run(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/summary-tasks-bot
+
+go 1.20

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,0 +1,127 @@
+package app
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/example/summary-tasks-bot/internal/repository"
+	"github.com/example/summary-tasks-bot/internal/service"
+	"github.com/example/summary-tasks-bot/pkg/openai"
+	"github.com/example/summary-tasks-bot/pkg/telegram"
+)
+
+// App coordinates the services and telegram client.
+type App struct {
+	repo        repository.UserSettingsRepository
+	userService *service.UserService
+	tgClient    *telegram.Client
+	aiClient    *openai.Client
+}
+
+func New(telegramToken string, aiToken string, repo repository.UserSettingsRepository) *App {
+	return &App{
+		repo:     repo,
+		tgClient: telegram.NewClient(telegramToken),
+		aiClient: openai.NewClient(aiToken),
+	}
+}
+
+func (a *App) Run(ctx context.Context) error {
+	a.userService = service.NewUserService(a.repo, a.aiClient)
+
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt)
+	defer stop()
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		a.handleUpdates(ctx)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		a.scheduleMessages(ctx)
+	}()
+
+	<-ctx.Done()
+	wg.Wait()
+	return nil
+}
+
+func (a *App) handleUpdates(ctx context.Context) {
+	offset := 0
+	for {
+		updates, err := a.tgClient.GetUpdates(ctx, offset)
+		if err != nil {
+			log.Println("get updates:", err)
+			time.Sleep(time.Second)
+			continue
+		}
+		for _, u := range updates {
+			offset = u.UpdateID + 1
+			if u.Message == nil {
+				continue
+			}
+			a.handleMessage(ctx, u.Message)
+		}
+	}
+}
+
+func (a *App) handleMessage(ctx context.Context, m *telegram.Message) {
+	switch m.Text {
+	case "/start":
+		if err := a.userService.Start(ctx, m.Chat.ID); err != nil {
+			log.Println("start:", err)
+		} else {
+			a.tgClient.SendMessage(ctx, m.Chat.ID, "Welcome! Use /update_topics to set topics.")
+		}
+	case "/stop":
+		if err := a.userService.Stop(ctx, m.Chat.ID); err != nil {
+			log.Println("stop:", err)
+		} else {
+			a.tgClient.SendMessage(ctx, m.Chat.ID, "Stopped updates")
+		}
+	default:
+		if strings.HasPrefix(m.Text, "/update_topics ") {
+			topics := strings.Fields(m.Text[len("/update_topics "):])
+			if err := a.userService.UpdateTopics(ctx, m.Chat.ID, topics); err != nil {
+				log.Println("update_topics:", err)
+			} else {
+				a.tgClient.SendMessage(ctx, m.Chat.ID, "Topics updated")
+			}
+		}
+	}
+}
+
+func (a *App) scheduleMessages(ctx context.Context) {
+	ticker := time.NewTicker(1 * time.Hour)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			users, err := a.userService.ActiveUsers(ctx)
+			if err != nil {
+				log.Println("active users:", err)
+				continue
+			}
+			for _, u := range users {
+				msg, err := a.userService.GetNews(ctx, u.Topics)
+				if err != nil {
+					log.Println("get news:", err)
+					continue
+				}
+				a.tgClient.SendMessage(ctx, u.UserID, msg)
+			}
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"errors"
+	"os"
+)
+
+// Config holds runtime configuration loaded from the environment.
+type Config struct {
+	TelegramToken string
+	OpenAIToken   string
+	SettingsPath  string
+}
+
+// FromEnv loads configuration from environment variables. TELEGRAM_TOKEN is required.
+// OPENAI_TOKEN is optional but should be set if OpenAI integration is needed.
+// SETTINGS_FILE specifies the path to the user settings JSON file and defaults
+// to "settings.json" if empty.
+func FromEnv() (*Config, error) {
+	c := &Config{
+		TelegramToken: os.Getenv("TELEGRAM_TOKEN"),
+		OpenAIToken:   os.Getenv("OPENAI_TOKEN"),
+		SettingsPath:  os.Getenv("SETTINGS_FILE"),
+	}
+	if c.TelegramToken == "" {
+		return nil, errors.New("TELEGRAM_TOKEN is not set")
+	}
+	if c.SettingsPath == "" {
+		c.SettingsPath = "settings.json"
+	}
+	return c, nil
+}

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -1,0 +1,15 @@
+package model
+
+// UserSettings stores preferences for a Telegram user.
+type UserSettings struct {
+	UserID int64    `json:"user_id"`
+	Topics []string `json:"topics"`
+	Active bool     `json:"active"`
+}
+
+// Subscription represents a scheduled message subscription.
+type Subscription struct {
+	UserID int64 `json:"user_id"`
+	// cron-like or interval; for simplicity use seconds interval
+	IntervalSec int `json:"interval_sec"`
+}

--- a/internal/repository/user_settings.go
+++ b/internal/repository/user_settings.go
@@ -1,0 +1,95 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"sync"
+
+	"github.com/example/summary-tasks-bot/internal/model"
+)
+
+type UserSettingsRepository interface {
+	Get(ctx context.Context, userID int64) (*model.UserSettings, error)
+	Save(ctx context.Context, settings *model.UserSettings) error
+	Delete(ctx context.Context, userID int64) error
+	List(ctx context.Context) ([]*model.UserSettings, error)
+}
+
+// FileUserSettingsRepository stores settings in a JSON file.
+type FileUserSettingsRepository struct {
+	path string
+	mu   sync.Mutex
+	data map[int64]*model.UserSettings
+}
+
+func NewFileUserSettingsRepository(path string) (*FileUserSettingsRepository, error) {
+	r := &FileUserSettingsRepository{path: path, data: map[int64]*model.UserSettings{}}
+	if err := r.load(); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func (r *FileUserSettingsRepository) load() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	file, err := os.Open(r.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			r.data = map[int64]*model.UserSettings{}
+			return nil
+		}
+		return err
+	}
+	defer file.Close()
+	return json.NewDecoder(file).Decode(&r.data)
+}
+
+func (r *FileUserSettingsRepository) saveLocked() error {
+	file, err := os.Create(r.path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	enc := json.NewEncoder(file)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r.data)
+}
+
+func (r *FileUserSettingsRepository) Get(ctx context.Context, userID int64) (*model.UserSettings, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if s, ok := r.data[userID]; ok {
+		copy := *s
+		return &copy, nil
+	}
+	return nil, os.ErrNotExist
+}
+
+func (r *FileUserSettingsRepository) Save(ctx context.Context, settings *model.UserSettings) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	copy := *settings
+	r.data[settings.UserID] = &copy
+	return r.saveLocked()
+}
+
+func (r *FileUserSettingsRepository) Delete(ctx context.Context, userID int64) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.data, userID)
+	return r.saveLocked()
+}
+
+func (r *FileUserSettingsRepository) List(ctx context.Context) ([]*model.UserSettings, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	res := make([]*model.UserSettings, 0, len(r.data))
+	for _, s := range r.data {
+		copy := *s
+		res = append(res, &copy)
+	}
+	return res, nil
+}

--- a/internal/repository/user_settings_test.go
+++ b/internal/repository/user_settings_test.go
@@ -1,0 +1,37 @@
+package repository
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/example/summary-tasks-bot/internal/model"
+)
+
+func TestFileUserSettingsRepository_CRUD(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	repo, err := NewFileUserSettingsRepository(path)
+	if err != nil {
+		t.Fatalf("new repo: %v", err)
+	}
+	ctx := context.Background()
+	s := &model.UserSettings{UserID: 1, Topics: []string{"go"}, Active: true}
+	if err := repo.Save(ctx, s); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := repo.Get(ctx, 1)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.UserID != s.UserID || got.Topics[0] != "go" || !got.Active {
+		t.Fatalf("unexpected data: %#v", got)
+	}
+	if err := repo.Delete(ctx, 1); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := repo.Get(ctx, 1); !os.IsNotExist(err) {
+		t.Fatalf("expected not exist error, got %v", err)
+	}
+}

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -1,0 +1,74 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/example/summary-tasks-bot/internal/model"
+	"github.com/example/summary-tasks-bot/internal/repository"
+)
+
+// AIClient describes the part of the OpenAI client used by the service.
+type AIClient interface {
+	ChatCompletion(ctx context.Context, prompt string) (string, error)
+}
+
+type UserService struct {
+	repo   repository.UserSettingsRepository
+	openai AIClient
+}
+
+func NewUserService(repo repository.UserSettingsRepository, ai AIClient) *UserService {
+	return &UserService{repo: repo, openai: ai}
+}
+
+// Start activates a user with default topics.
+func (s *UserService) Start(ctx context.Context, userID int64) error {
+	settings := &model.UserSettings{UserID: userID, Topics: []string{"golang"}, Active: true}
+	return s.repo.Save(ctx, settings)
+}
+
+// UpdateTopics sets the topics for the user.
+func (s *UserService) UpdateTopics(ctx context.Context, userID int64, topics []string) error {
+	settings, err := s.repo.Get(ctx, userID)
+	if err != nil {
+		return err
+	}
+	settings.Topics = topics
+	return s.repo.Save(ctx, settings)
+}
+
+// Stop deactivates the user.
+func (s *UserService) Stop(ctx context.Context, userID int64) error {
+	settings, err := s.repo.Get(ctx, userID)
+	if err != nil {
+		return err
+	}
+	settings.Active = false
+	return s.repo.Save(ctx, settings)
+}
+
+// GetNews returns news about the provided topics using the OpenAI API.
+func (s *UserService) GetNews(ctx context.Context, topics []string) (string, error) {
+	prompt := fmt.Sprintf("Give me the latest news about %s in two sentences.", strings.Join(topics, ", "))
+	if s.openai == nil {
+		return fmt.Sprintf("Latest news about %s", strings.Join(topics, ", ")), nil
+	}
+	return s.openai.ChatCompletion(ctx, prompt)
+}
+
+// ActiveUsers returns all active users.
+func (s *UserService) ActiveUsers(ctx context.Context) ([]*model.UserSettings, error) {
+	all, err := s.repo.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := []*model.UserSettings{}
+	for _, u := range all {
+		if u.Active {
+			out = append(out, u)
+		}
+	}
+	return out, nil
+}

--- a/internal/service/user_test.go
+++ b/internal/service/user_test.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/example/summary-tasks-bot/internal/model"
+	"github.com/example/summary-tasks-bot/internal/repository"
+)
+
+type memRepo struct {
+	data map[int64]*model.UserSettings
+}
+
+var _ repository.UserSettingsRepository = (*memRepo)(nil)
+
+func newMemRepo() *memRepo {
+	return &memRepo{data: map[int64]*model.UserSettings{}}
+}
+
+func (m *memRepo) Get(ctx context.Context, userID int64) (*model.UserSettings, error) {
+	if s, ok := m.data[userID]; ok {
+		copy := *s
+		return &copy, nil
+	}
+	return nil, os.ErrNotExist
+}
+
+func (m *memRepo) Save(ctx context.Context, settings *model.UserSettings) error {
+	c := *settings
+	m.data[settings.UserID] = &c
+	return nil
+}
+
+func (m *memRepo) Delete(ctx context.Context, userID int64) error {
+	delete(m.data, userID)
+	return nil
+}
+
+func (m *memRepo) List(ctx context.Context) ([]*model.UserSettings, error) {
+	out := []*model.UserSettings{}
+	for _, s := range m.data {
+		c := *s
+		out = append(out, &c)
+	}
+	return out, nil
+}
+
+func TestUserService_StartStop(t *testing.T) {
+	repo := newMemRepo()
+	svc := NewUserService(repo, nil)
+	ctx := context.Background()
+
+	if err := svc.Start(ctx, 1); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	u, _ := repo.Get(ctx, 1)
+	if !u.Active {
+		t.Fatalf("expected active")
+	}
+	if err := svc.Stop(ctx, 1); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	u, _ = repo.Get(ctx, 1)
+	if u.Active {
+		t.Fatalf("expected inactive")
+	}
+}

--- a/pkg/openai/client.go
+++ b/pkg/openai/client.go
@@ -1,0 +1,67 @@
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+)
+
+type Client struct {
+	token      string
+	baseURL    string
+	httpClient *http.Client
+}
+
+func NewClient(token string) *Client {
+	return &Client{
+		token:      token,
+		baseURL:    "https://api.openai.com/v1",
+		httpClient: http.DefaultClient,
+	}
+}
+
+func (c *Client) do(ctx context.Context, endpoint string, body any, out any) error {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+endpoint, bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("openai: unexpected status " + resp.Status)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// ChatCompletion sends a minimal chat completion request using the gpt-3.5-turbo model.
+func (c *Client) ChatCompletion(ctx context.Context, prompt string) (string, error) {
+	reqBody := map[string]any{
+		"model":    "gpt-3.5-turbo",
+		"messages": []map[string]string{{"role": "user", "content": prompt}},
+	}
+	var respBody struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := c.do(ctx, "/chat/completions", reqBody, &respBody); err != nil {
+		return "", err
+	}
+	if len(respBody.Choices) == 0 {
+		return "", errors.New("openai: empty response")
+	}
+	return respBody.Choices[0].Message.Content, nil
+}

--- a/pkg/telegram/client.go
+++ b/pkg/telegram/client.go
@@ -1,0 +1,97 @@
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Update represents a Telegram update. Only fields we need.
+type Update struct {
+	UpdateID int      `json:"update_id"`
+	Message  *Message `json:"message,omitempty"`
+}
+
+type Message struct {
+	MessageID int    `json:"message_id"`
+	Chat      Chat   `json:"chat"`
+	Text      string `json:"text"`
+}
+
+type Chat struct {
+	ID int64 `json:"id"`
+}
+
+// Client is a minimal Telegram Bot API client.
+type Client struct {
+	token      string
+	baseURL    string
+	httpClient *http.Client
+}
+
+func NewClient(token string) *Client {
+	return &Client{
+		token:      token,
+		baseURL:    "https://api.telegram.org",
+		httpClient: http.DefaultClient,
+	}
+}
+
+func (c *Client) url(method string) string {
+	return c.baseURL + "/bot" + c.token + "/" + method
+}
+
+func (c *Client) SendMessage(ctx context.Context, chatID int64, text string) error {
+	form := url.Values{}
+	form.Set("chat_id", strconv.FormatInt(chatID, 10))
+	form.Set("text", text)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url("sendMessage"), strings.NewReader(form.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("telegram: unexpected status " + resp.Status)
+	}
+	return nil
+}
+
+func (c *Client) GetUpdates(ctx context.Context, offset int) ([]Update, error) {
+	q := url.Values{}
+	if offset != 0 {
+		q.Set("offset", strconv.Itoa(offset))
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url("getUpdates"), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.URL.RawQuery = q.Encode()
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New("telegram: unexpected status " + resp.Status)
+	}
+	var wrapper struct {
+		OK     bool     `json:"ok"`
+		Result []Update `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&wrapper); err != nil {
+		return nil, err
+	}
+	if !wrapper.OK {
+		return nil, errors.New("telegram: api responded with not ok")
+	}
+	return wrapper.Result, nil
+}


### PR DESCRIPTION
## Summary
- add environment-based config loader
- add OpenAI client
- use OpenAI in `UserService` via new interface
- update `App` to initialize clients
- provide executable `cmd/bot` example
- document environment variables for tokens

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687bc04239448320acf1e4f80978bbf2