### PR TITLE
Add settings management with logging

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,15 @@
+name: Go CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.20
+      - run: go test ./...
+      - run: go build ./cmd/telegrambot
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.20-alpine AS build
+WORKDIR /app
+COPY . .
+RUN go build -o telegrambot ./cmd/telegrambot
+
+FROM alpine:latest
+WORKDIR /app
+COPY --from=build /app/telegrambot .
+CMD ["./telegrambot"]
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Telegram Bot with GPT
+
+This project is a Go-based Telegram bot that can send invites, ideas, news, and more. The bot is designed with a simple layered architecture and can run in Docker.
+
+## Project Structure
+
+```
+cmd/telegrambot       Entry point
+internal/app          Application coordination
+internal/service      Business logic services
+internal/repository   Data access layer
+internal/model        Shared data types
+pkg/                  Reusable packages
+config/               Configuration files
+```
+
+## Quick Start
+
+```bash
+go build ./cmd/telegrambot
+./telegrambot
+```
+
+Or run with Docker:
+
+```bash
+docker build -t telegrambot .
+docker run telegrambot
+```
+
+## Testing
+
+Run all unit tests:
+
+```bash
+go test ./...
+```
+
+The project is built and tested automatically using GitHub Actions.
+

--- a/cmd/telegrambot/main.go
+++ b/cmd/telegrambot/main.go
@@ -1,0 +1,8 @@
+package main
+
+import "github.com/example/telegrambot/internal/app"
+
+func main() {
+	a := app.New()
+	a.Run()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/telegrambot
+
+go 1.24.3

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,0 +1,37 @@
+package app
+
+import (
+	"log"
+
+	"github.com/example/telegrambot/internal/repository"
+	"github.com/example/telegrambot/internal/service"
+)
+
+// App coordinates the services and repositories.
+type App struct {
+	settings *service.SettingsService
+}
+
+// New creates a new App instance.
+func New() *App {
+	repo := repository.NewSettingsRepository()
+	settings := service.NewSettingsService(repo)
+	return &App{settings: settings}
+}
+
+// Run starts the bot and triggers the initial setup flow.
+func (a *App) Run() {
+	log.Println("bot started")
+	a.settings.Start()
+}
+
+// ShowConfig logs current user settings.
+func (a *App) ShowConfig() {
+	cfg := a.settings.GetSettings()
+	log.Printf("current settings: info_type=%s topics=%v", cfg.InfoType, cfg.Topics)
+}
+
+// RemoveTopic removes the specified topic or all topics.
+func (a *App) RemoveTopic(topic string) {
+	a.settings.DeleteTopic(topic)
+}

--- a/internal/model/news.go
+++ b/internal/model/news.go
@@ -1,0 +1,7 @@
+package model
+
+// NewsItem represents one piece of news.
+type NewsItem struct {
+	Title string
+	URL   string
+}

--- a/internal/model/settings.go
+++ b/internal/model/settings.go
@@ -1,0 +1,7 @@
+package model
+
+// Settings stores user preferences.
+type Settings struct {
+	InfoType string   // what kind of info user wants
+	Topics   []string // list of topics
+}

--- a/internal/repository/news.go
+++ b/internal/repository/news.go
@@ -1,0 +1,13 @@
+package repository
+
+// NewsRepository fetches news from storage.
+type NewsRepository struct{}
+
+func NewNewsRepository() *NewsRepository {
+	return &NewsRepository{}
+}
+
+func (r *NewsRepository) GetLatest() []string {
+	// Placeholder implementation
+	return []string{"news 1", "news 2"}
+}

--- a/internal/repository/settings.go
+++ b/internal/repository/settings.go
@@ -1,0 +1,20 @@
+package repository
+
+import "github.com/example/telegrambot/internal/model"
+
+// SettingsRepository stores user settings in memory.
+type SettingsRepository struct {
+	settings model.Settings
+}
+
+func NewSettingsRepository() *SettingsRepository {
+	return &SettingsRepository{}
+}
+
+func (r *SettingsRepository) Save(s model.Settings) {
+	r.settings = s
+}
+
+func (r *SettingsRepository) Load() model.Settings {
+	return r.settings
+}

--- a/internal/service/news.go
+++ b/internal/service/news.go
@@ -1,0 +1,13 @@
+package service
+
+// NewsService returns news items.
+type NewsService struct{}
+
+func NewNewsService() *NewsService {
+	return &NewsService{}
+}
+
+func (s *NewsService) Latest() []string {
+	// Placeholder: fetch latest news from repository
+	return []string{"news 1", "news 2"}
+}

--- a/internal/service/news_test.go
+++ b/internal/service/news_test.go
@@ -1,0 +1,11 @@
+package service
+
+import "testing"
+
+func TestNewsService_Latest(t *testing.T) {
+	s := NewNewsService()
+	got := s.Latest()
+	if len(got) == 0 {
+		t.Fatalf("expected some news")
+	}
+}

--- a/internal/service/settings.go
+++ b/internal/service/settings.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"log"
+
+	"github.com/example/telegrambot/internal/model"
+	"github.com/example/telegrambot/internal/repository"
+)
+
+// SettingsService manages user preferences.
+type SettingsService struct {
+	repo *repository.SettingsRepository
+}
+
+func NewSettingsService(repo *repository.SettingsRepository) *SettingsService {
+	return &SettingsService{repo: repo}
+}
+
+// Start initiates configuration flow.
+func (s *SettingsService) Start() {
+	log.Println("select info type: insight, news, idea, fact")
+}
+
+// SetInfoType stores desired info type.
+func (s *SettingsService) SetInfoType(t string) {
+	cfg := s.repo.Load()
+	cfg.InfoType = t
+	s.repo.Save(cfg)
+	log.Printf("info type set to %s", t)
+}
+
+// AddTopic appends a topic without removing existing ones.
+func (s *SettingsService) AddTopic(topic string) {
+	cfg := s.repo.Load()
+	for _, t := range cfg.Topics {
+		if t == topic {
+			s.repo.Save(cfg)
+			return
+		}
+	}
+	cfg.Topics = append(cfg.Topics, topic)
+	s.repo.Save(cfg)
+	log.Printf("topic %s added", topic)
+}
+
+// GetSettings returns current settings.
+func (s *SettingsService) GetSettings() model.Settings {
+	return s.repo.Load()
+}
+
+// DeleteTopic removes a single topic or all topics when topic is "all".
+func (s *SettingsService) DeleteTopic(topic string) {
+	cfg := s.repo.Load()
+	if topic == "all" || topic == "" {
+		cfg.Topics = nil
+		s.repo.Save(cfg)
+		log.Println("all topics deleted")
+		return
+	}
+	topics := []string{}
+	for _, t := range cfg.Topics {
+		if t != topic {
+			topics = append(topics, t)
+		}
+	}
+	cfg.Topics = topics
+	s.repo.Save(cfg)
+	log.Printf("topic %s deleted", topic)
+}

--- a/internal/service/settings_test.go
+++ b/internal/service/settings_test.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/example/telegrambot/internal/repository"
+)
+
+func TestSettingsService_AddAndDeleteTopics(t *testing.T) {
+	repo := repository.NewSettingsRepository()
+	s := NewSettingsService(repo)
+
+	s.AddTopic("health")
+	s.AddTopic("sport")
+	cfg := s.GetSettings()
+	if len(cfg.Topics) != 2 {
+		t.Fatalf("expected 2 topics, got %d", len(cfg.Topics))
+	}
+
+	s.DeleteTopic("health")
+	cfg = s.GetSettings()
+	if len(cfg.Topics) != 1 || cfg.Topics[0] != "sport" {
+		t.Fatalf("topic removal failed: %+v", cfg.Topics)
+	}
+
+	s.DeleteTopic("all")
+	cfg = s.GetSettings()
+	if len(cfg.Topics) != 0 {
+		t.Fatalf("expected all topics removed")
+	}
+}


### PR DESCRIPTION
## Summary
- implement SettingsService to manage info type and topics
- log bot startup and settings operations
- expose methods on App to show and delete topics
- test settings service for add/delete logic

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687bb989fc948320a4553ff9d49f01f9