### PR TITLE
Remove topics field and send initial message

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ It is intentionally minimal and uses only the standard library.
 
 The bot understands the following commands:
 
-* `/start` – start receiving periodic updates about default topics.
-* `/update_topics <topic1> <topic2>` – change the topics you are interested in.
+* `/start` – start receiving periodic updates about default categories.
+* `/update_topics <topic1> <topic2>` – update the categories you are interested in.
 * `/get_news_now` – request an immediate news summary based on your preferences.
 * `/my_topics` – show your selected info types and categories.
 * `/stop` – stop receiving updates.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -343,7 +343,6 @@ func (a *App) continueConversation(ctx context.Context, m *telegram.Message, c *
 
 		settings := &model.UserSettings{
 			UserID:            m.Chat.ID,
-			Topics:            c.Categories,
 			InfoTypes:         c.InfoTypes,
 			Categories:        c.Categories,
 			Tariff:            "base",
@@ -356,6 +355,12 @@ func (a *App) continueConversation(ctx context.Context, m *telegram.Message, c *
 			log.Println("save settings:", err)
 		} else {
 			a.tgClient.SendMessage(ctx, m.Chat.ID, "Настройки сохранены", nil)
+			msg, err := a.userService.GetNews(ctx, settings)
+			if err == nil {
+				a.tgClient.SendMessage(ctx, m.Chat.ID, msg, nil)
+			} else {
+				log.Println("get news:", err)
+			}
 		}
 		delete(a.convs, m.Chat.ID)
 	}

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -3,7 +3,6 @@ package model
 // UserSettings stores preferences for a Telegram user.
 type UserSettings struct {
 	UserID            int64    `json:"user_id"`
-	Topics            []string `json:"topics"`
 	Active            bool     `json:"active"`
 	InfoTypes         []string `json:"info_types,omitempty"`
 	Categories        []string `json:"categories,omitempty"`

--- a/internal/repository/postgres_user_settings.go
+++ b/internal/repository/postgres_user_settings.go
@@ -32,7 +32,6 @@ func (r *PostgresUserSettingsRepository) init() error {
 	_, err := r.db.Exec(`
         CREATE TABLE IF NOT EXISTS user_settings (
             user_id BIGINT PRIMARY KEY,
-            topics JSONB,
             active BOOLEAN,
             info_types JSONB,
             categories JSONB,
@@ -46,26 +45,21 @@ func (r *PostgresUserSettingsRepository) init() error {
 }
 
 func (r *PostgresUserSettingsRepository) Get(ctx context.Context, userID int64) (*model.UserSettings, error) {
-	row := r.db.QueryRowContext(ctx, `SELECT user_id, topics, active, info_types, categories, frequency, tariff, last_scheduled_sent, last_get_news_now, get_news_now_count FROM user_settings WHERE user_id=$1`, userID)
+	row := r.db.QueryRowContext(ctx, `SELECT user_id, active, info_types, categories, frequency, tariff, last_scheduled_sent, last_get_news_now, get_news_now_count FROM user_settings WHERE user_id=$1`, userID)
 	var s model.UserSettings
-	var topics, infoTypes, categories []byte
-	if err := row.Scan(&s.UserID, &topics, &s.Active, &infoTypes, &categories, &s.Frequency, &s.Tariff, &s.LastScheduledSent, &s.LastGetNewsNow, &s.GetNewsNowCount); err != nil {
+	var infoTypes, categories []byte
+	if err := row.Scan(&s.UserID, &s.Active, &infoTypes, &categories, &s.Frequency, &s.Tariff, &s.LastScheduledSent, &s.LastGetNewsNow, &s.GetNewsNowCount); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, errors.New("not found")
 		}
 		return nil, err
 	}
-	json.Unmarshal(topics, &s.Topics)
 	json.Unmarshal(infoTypes, &s.InfoTypes)
 	json.Unmarshal(categories, &s.Categories)
 	return &s, nil
 }
 
 func (r *PostgresUserSettingsRepository) Save(ctx context.Context, settings *model.UserSettings) error {
-	topics, err := json.Marshal(settings.Topics)
-	if err != nil {
-		return err
-	}
 	infoTypes, err := json.Marshal(settings.InfoTypes)
 	if err != nil {
 		return err
@@ -75,10 +69,9 @@ func (r *PostgresUserSettingsRepository) Save(ctx context.Context, settings *mod
 		return err
 	}
 	_, err = r.db.ExecContext(ctx, `
-        INSERT INTO user_settings (user_id, topics, active, info_types, categories, frequency, tariff, last_scheduled_sent, last_get_news_now, get_news_now_count)
-        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+        INSERT INTO user_settings (user_id, active, info_types, categories, frequency, tariff, last_scheduled_sent, last_get_news_now, get_news_now_count)
+        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
         ON CONFLICT (user_id) DO UPDATE SET
-            topics=EXCLUDED.topics,
             active=EXCLUDED.active,
             info_types=EXCLUDED.info_types,
             categories=EXCLUDED.categories,
@@ -87,7 +80,7 @@ func (r *PostgresUserSettingsRepository) Save(ctx context.Context, settings *mod
             last_scheduled_sent=EXCLUDED.last_scheduled_sent,
             last_get_news_now=EXCLUDED.last_get_news_now,
             get_news_now_count=EXCLUDED.get_news_now_count
-    `, settings.UserID, string(topics), settings.Active, string(infoTypes), string(categories), settings.Frequency, settings.Tariff, settings.LastScheduledSent, settings.LastGetNewsNow, settings.GetNewsNowCount)
+    `, settings.UserID, settings.Active, string(infoTypes), string(categories), settings.Frequency, settings.Tariff, settings.LastScheduledSent, settings.LastGetNewsNow, settings.GetNewsNowCount)
 	return err
 }
 
@@ -97,7 +90,7 @@ func (r *PostgresUserSettingsRepository) Delete(ctx context.Context, userID int6
 }
 
 func (r *PostgresUserSettingsRepository) List(ctx context.Context) ([]*model.UserSettings, error) {
-	rows, err := r.db.QueryContext(ctx, `SELECT user_id, topics, active, info_types, categories, frequency, tariff, last_scheduled_sent, last_get_news_now, get_news_now_count FROM user_settings`)
+	rows, err := r.db.QueryContext(ctx, `SELECT user_id, active, info_types, categories, frequency, tariff, last_scheduled_sent, last_get_news_now, get_news_now_count FROM user_settings`)
 	if err != nil {
 		return nil, err
 	}
@@ -105,11 +98,10 @@ func (r *PostgresUserSettingsRepository) List(ctx context.Context) ([]*model.Use
 	var result []*model.UserSettings
 	for rows.Next() {
 		var s model.UserSettings
-		var topics, infoTypes, categories []byte
-		if err := rows.Scan(&s.UserID, &topics, &s.Active, &infoTypes, &categories, &s.Frequency, &s.Tariff, &s.LastScheduledSent, &s.LastGetNewsNow, &s.GetNewsNowCount); err != nil {
+		var infoTypes, categories []byte
+		if err := rows.Scan(&s.UserID, &s.Active, &infoTypes, &categories, &s.Frequency, &s.Tariff, &s.LastScheduledSent, &s.LastGetNewsNow, &s.GetNewsNowCount); err != nil {
 			return nil, err
 		}
-		json.Unmarshal(topics, &s.Topics)
 		json.Unmarshal(infoTypes, &s.InfoTypes)
 		json.Unmarshal(categories, &s.Categories)
 		result = append(result, &s)

--- a/internal/repository/user_settings_test.go
+++ b/internal/repository/user_settings_test.go
@@ -17,7 +17,7 @@ func TestFileUserSettingsRepository_CRUD(t *testing.T) {
 		t.Fatalf("new repo: %v", err)
 	}
 	ctx := context.Background()
-	s := &model.UserSettings{UserID: 1, Topics: []string{"go"}, Active: true}
+	s := &model.UserSettings{UserID: 1, Categories: []string{"go"}, Active: true}
 	if err := repo.Save(ctx, s); err != nil {
 		t.Fatalf("save: %v", err)
 	}
@@ -25,7 +25,7 @@ func TestFileUserSettingsRepository_CRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
-	if got.UserID != s.UserID || got.Topics[0] != "go" || !got.Active {
+	if got.UserID != s.UserID || got.Categories[0] != "go" || !got.Active {
 		t.Fatalf("unexpected data: %#v", got)
 	}
 	if err := repo.Delete(ctx, 1); err != nil {

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -28,32 +28,19 @@ func NewUserService(repo repository.UserSettingsRepository, ai AIClient, tariffs
 	return &UserService{repo: repo, openai: ai, tariffs: tariffs}
 }
 
-// Start activates a user with default topics.
+// Start activates a user with default settings.
 func (s *UserService) Start(ctx context.Context, userID int64) error {
 	settings, err := s.repo.Get(ctx, userID)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
-		settings = &model.UserSettings{UserID: userID, Topics: []string{"golang"}}
-	}
-	if len(settings.Topics) == 0 {
-		settings.Topics = []string{"golang"}
+		settings = &model.UserSettings{UserID: userID}
 	}
 	if settings.Tariff == "" {
 		settings.Tariff = "base"
 	}
 	settings.Active = true
-	return s.repo.Save(ctx, settings)
-}
-
-// UpdateTopics sets the topics for the user.
-func (s *UserService) UpdateTopics(ctx context.Context, userID int64, topics []string) error {
-	settings, err := s.repo.Get(ctx, userID)
-	if err != nil {
-		return err
-	}
-	settings.Topics = topics
 	return s.repo.Save(ctx, settings)
 }
 
@@ -67,7 +54,7 @@ func (s *UserService) Stop(ctx context.Context, userID int64) error {
 	return s.repo.Save(ctx, settings)
 }
 
-// GetNews returns news about the provided topics using the OpenAI API.
+// GetNews returns news according to the user preferences using the OpenAI API.
 func (s *UserService) GetNews(ctx context.Context, u *model.UserSettings) (string, error) {
 	info := ""
 	if len(u.InfoTypes) > 0 {


### PR DESCRIPTION
## Summary
- remove `Topics` from user settings
- migrate database repository to store only categories
- send the first news message right after saving new user settings
- update docs and tests

## Testing
- `go test ./...` *(fails: missing go modules)*

------
https://chatgpt.com/codex/tasks/task_e_6880d71a03ec8320b8359394de50d01a