### PR TITLE
Improve error logging and OpenAI client

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -124,6 +124,20 @@ func New(cfg *config.Config, repo repository.UserSettingsRepository) *App {
 	}
 }
 
+func (a *App) sendMessage(ctx context.Context, chatID int64, text string, kb [][]string) (int, error) {
+	msgID, err := a.tgClient.SendMessage(ctx, chatID, text, kb)
+	if err != nil {
+		log.Printf("telegram send message: %v", err)
+	}
+	return msgID, err
+}
+
+func (a *App) deleteMessage(ctx context.Context, chatID int64, messageID int) {
+	if err := a.tgClient.DeleteMessage(ctx, chatID, messageID); err != nil {
+		log.Printf("telegram delete message: %v", err)
+	}
+}
+
 func (a *App) Run(ctx context.Context) error {
 	log.Println("application starting")
 	a.userService = service.NewUserService(a.repo, a.aiClient, a.cfg.Tariffs)
@@ -201,7 +215,7 @@ func (a *App) handleMessage(ctx context.Context, m *telegram.Message) {
 	default:
 		log.Printf("user %d(@%s) texted: %s", m.Chat.ID, m.Chat.Username, m.Text)
 		promt := "Я не понимаю текст вне команд. Чтобы увидеть команды, нажми кнопку `Меню` или вызови команду  `/start`"
-		_, _ = a.tgClient.SendMessage(ctx, m.Chat.ID, promt, nil)
+		a.sendMessage(ctx, m.Chat.ID, promt, nil)
 	}
 }
 
@@ -255,7 +269,7 @@ func (a *App) scheduleMessages(ctx context.Context) {
 					log.Println("get news:", err)
 					continue
 				}
-				_, _ = a.tgClient.SendMessage(ctx, u.UserID, msg, nil)
+				a.sendMessage(ctx, u.UserID, msg, nil)
 				log.Printf("user %d(@%s) got scheduled news", u.UserID, u.UserName)
 
 				u.LastScheduledSent = now.Unix()
@@ -285,12 +299,12 @@ func (a *App) continueConversation(ctx context.Context, m *telegram.Message, c *
 	switch c.Stage {
 	case stageWelcome:
 		if strings.TrimSpace(m.Text) != "Продолжить" {
-			msg, _ := a.tgClient.SendMessage(ctx, m.Chat.ID, "Нажмите 'Продолжить'", [][]string{{"Продолжить"}})
+			msg, _ := a.sendMessage(ctx, m.Chat.ID, "Нажмите 'Продолжить'", [][]string{{"Продолжить"}})
 			c.LastMsgID = msg
 			return
 		}
-		a.tgClient.DeleteMessage(ctx, m.Chat.ID, m.MessageID)
-		a.tgClient.DeleteMessage(ctx, m.Chat.ID, c.LastMsgID)
+		a.deleteMessage(ctx, m.Chat.ID, m.MessageID)
+		a.deleteMessage(ctx, m.Chat.ID, c.LastMsgID)
 		t := a.cfg.Tariffs["base"]
 		c.Stage = stageCategory
 		c.Step = 0
@@ -299,18 +313,18 @@ func (a *App) continueConversation(ctx context.Context, m *telegram.Message, c *
 		c.AllowCustomCategory = t.AllowCustomCategory
 		opts := addCustomOption(a.categoryOptions, c.AllowCustomCategory)
 		prompt := fmt.Sprintf("Выберите категорию №1:\n%s\nВведите номер.", formatOptions(opts))
-		msgID, _ := a.tgClient.SendMessage(ctx, m.Chat.ID, prompt, numberKeyboard(len(opts)))
+		msgID, _ := a.sendMessage(ctx, m.Chat.ID, prompt, numberKeyboard(len(opts)))
 		c.LastMsgID = msgID
 
 	case stageUpdateChoice:
 		choice := parseSelection(m.Text, []string{"Обновить все", "Обновить одну"}, 1)
 		if len(choice) == 0 {
-			msg, _ := a.tgClient.SendMessage(ctx, m.Chat.ID, "Выберите действие", [][]string{{"1", "2"}})
+			msg, _ := a.sendMessage(ctx, m.Chat.ID, "Выберите действие", [][]string{{"1", "2"}})
 			c.LastMsgID = msg
 			return
 		}
-		a.tgClient.DeleteMessage(ctx, m.Chat.ID, m.MessageID)
-		a.tgClient.DeleteMessage(ctx, m.Chat.ID, c.LastMsgID)
+		a.deleteMessage(ctx, m.Chat.ID, m.MessageID)
+		a.deleteMessage(ctx, m.Chat.ID, c.LastMsgID)
 		if choice[0] == "Обновить одну" {
 			c.CategoryLimit = 1
 			c.AvailableCats = make([]string, 0, len(c.Topics))
@@ -319,7 +333,7 @@ func (a *App) continueConversation(ctx context.Context, m *telegram.Message, c *
 			}
 			c.Stage = stageSelectExistingCategory
 			prompt := fmt.Sprintf("Какую категорию обновить?\n%s\nВведите номер.", formatOptions(c.AvailableCats))
-			msgID, _ := a.tgClient.SendMessage(ctx, m.Chat.ID, prompt, numberKeyboard(len(c.AvailableCats)))
+			msgID, _ := a.sendMessage(ctx, m.Chat.ID, prompt, numberKeyboard(len(c.AvailableCats)))
 			c.LastMsgID = msgID
 			return
 		}
@@ -329,71 +343,71 @@ func (a *App) continueConversation(ctx context.Context, m *telegram.Message, c *
 		c.Stage = stageCategory
 		opts := addCustomOption(a.categoryOptions, c.AllowCustomCategory)
 		prompt := fmt.Sprintf("Выберите категорию №1:\n%s\nВведите номер.", formatOptions(opts))
-		msgID, _ := a.tgClient.SendMessage(ctx, m.Chat.ID, prompt, numberKeyboard(len(opts)))
+		msgID, _ := a.sendMessage(ctx, m.Chat.ID, prompt, numberKeyboard(len(opts)))
 		c.LastMsgID = msgID
 
 	case stageSelectExistingCategory:
 		cats := parseSelection(m.Text, c.AvailableCats, 1)
 		if len(cats) == 0 {
-			msg, _ := a.tgClient.SendMessage(ctx, m.Chat.ID, "Выберите номер категории", numberKeyboard(len(c.AvailableCats)))
+			msg, _ := a.sendMessage(ctx, m.Chat.ID, "Выберите номер категории", numberKeyboard(len(c.AvailableCats)))
 			c.LastMsgID = msg
 			return
 		}
-		a.tgClient.DeleteMessage(ctx, m.Chat.ID, m.MessageID)
-		a.tgClient.DeleteMessage(ctx, m.Chat.ID, c.LastMsgID)
+		a.deleteMessage(ctx, m.Chat.ID, m.MessageID)
+		a.deleteMessage(ctx, m.Chat.ID, c.LastMsgID)
 		c.OldCat = cats[0]
 		c.Stage = stageCategory
 		opts := addCustomOption(a.categoryOptions, c.AllowCustomCategory)
 		prompt := fmt.Sprintf("Выберите новую категорию вместо '%s':\n%s\nВведите номер.", c.OldCat, formatOptions(opts))
-		msgID, _ := a.tgClient.SendMessage(ctx, m.Chat.ID, prompt, numberKeyboard(len(opts)))
+		msgID, _ := a.sendMessage(ctx, m.Chat.ID, prompt, numberKeyboard(len(opts)))
 		c.LastMsgID = msgID
 
 	case stageCategory:
 		opts := addCustomOption(a.categoryOptions, c.AllowCustomCategory)
 		cats := parseSelection(m.Text, opts, 1)
 		if len(cats) == 0 {
-			msg, _ := a.tgClient.SendMessage(ctx, m.Chat.ID, "Выберите номер категории", numberKeyboard(len(opts)))
+			msg, _ := a.sendMessage(ctx, m.Chat.ID, "Выберите номер категории", numberKeyboard(len(opts)))
 			c.LastMsgID = msg
 			return
 		}
-		a.tgClient.DeleteMessage(ctx, m.Chat.ID, m.MessageID)
-		a.tgClient.DeleteMessage(ctx, m.Chat.ID, c.LastMsgID)
+		a.deleteMessage(ctx, m.Chat.ID, m.MessageID)
+		a.deleteMessage(ctx, m.Chat.ID, c.LastMsgID)
 		if c.AllowCustomCategory && cats[0] == "Своя категория" {
 			c.Stage = stageCustomCategory
-			msgID, _ := a.tgClient.SendMessage(ctx, m.Chat.ID, "Введите свою категорию (1-3 слова)", nil)
+			msgID, _ := a.sendMessage(ctx, m.Chat.ID, "Введите свою категорию (1-3 слова)", nil)
 			c.LastMsgID = msgID
 			return
 		}
 		c.CurrentCat = cats[0]
 		c.Stage = stageInfoTypes
 		prompt := fmt.Sprintf("Выберите типы информации для категории '%s':\n%s\nВведите номера через запятую (не более %d).", c.CurrentCat, formatOptions(a.infoOptions), c.InfoLimit)
-		msgID, _ := a.tgClient.SendMessage(ctx, m.Chat.ID, prompt, numberKeyboard(len(a.infoOptions)))
+		msgID, _ := a.sendMessage(ctx, m.Chat.ID, prompt, numberKeyboard(len(a.infoOptions)))
 		c.LastMsgID = msgID
 
 	case stageCustomCategory:
 		words := strings.Fields(m.Text)
 		if len(words) < 1 || len(words) > 3 {
-			msg, _ := a.tgClient.SendMessage(ctx, m.Chat.ID, "Введите от 1 до 3 слов", nil)
+			msg, _ := a.sendMessage(ctx, m.Chat.ID, "Введите от 1 до 3 слов", nil)
 			c.LastMsgID = msg
 			return
 		}
-		a.tgClient.DeleteMessage(ctx, m.Chat.ID, m.MessageID)
-		a.tgClient.DeleteMessage(ctx, m.Chat.ID, c.LastMsgID)
+		a.deleteMessage(ctx, m.Chat.ID, m.MessageID)
+		a.deleteMessage(ctx, m.Chat.ID, c.LastMsgID)
 		c.CurrentCat = strings.Join(words, " ")
 		c.Stage = stageInfoTypes
 		prompt := fmt.Sprintf("Выберите типы информации для категории '%s':\n%s\nВведите номера через запятую (не более %d).", c.CurrentCat, formatOptions(a.infoOptions), c.InfoLimit)
-		msgID, _ := a.tgClient.SendMessage(ctx, m.Chat.ID, prompt, numberKeyboard(len(a.infoOptions)))
+		msgID, _ := a.sendMessage(ctx, m.Chat.ID, prompt, numberKeyboard(len(a.infoOptions)))
 		c.LastMsgID = msgID
 
 	case stageInfoTypes:
 		infos := parseSelection(m.Text, a.infoOptions, c.InfoLimit)
 		if len(infos) == 0 {
-			msg, _ := a.tgClient.SendMessage(ctx, m.Chat.ID, "Введите номера типов информации", numberKeyboard(len(a.infoOptions)))
+			msg, _ := a.sendMessage(ctx, m.Chat.ID, "Введите номера типов информации", numberKeyboard(len(a.infoOptions)))
 			c.LastMsgID = msg
 			return
 		}
-		a.tgClient.DeleteMessage(ctx, m.Chat.ID, m.MessageID)
-		a.tgClient.DeleteMessage(ctx, m.Chat.ID, c.LastMsgID)
+		a.deleteMessage(ctx, m.Chat.ID, m.MessageID)
+		a.deleteMessage(ctx, m.Chat.ID, c.LastMsgID)
 		if c.Topics == nil {
 			c.Topics = map[string][]string{}
 		}
@@ -437,7 +451,7 @@ func (a *App) continueConversation(ctx context.Context, m *telegram.Message, c *
 					for cat, types := range c.Topics {
 						parts = append(parts, fmt.Sprintf("%s: %s", cat, strings.Join(types, ", ")))
 					}
-					_, _ = a.tgClient.SendMessage(ctx, m.Chat.ID, "Настройки обновлены:\n"+strings.Join(parts, "\n"), nil)
+					a.sendMessage(ctx, m.Chat.ID, "Настройки обновлены:\n"+strings.Join(parts, "\n"), nil)
 				}
 				delete(a.convs, m.Chat.ID)
 				return
@@ -460,10 +474,10 @@ func (a *App) continueConversation(ctx context.Context, m *telegram.Message, c *
 				for cat, types := range c.Topics {
 					parts = append(parts, fmt.Sprintf("%s: %s", cat, strings.Join(types, ", ")))
 				}
-				_, _ = a.tgClient.SendMessage(ctx, m.Chat.ID, "Настройки сохранены:\n"+strings.Join(parts, "\n"), nil)
+				a.sendMessage(ctx, m.Chat.ID, "Настройки сохранены:\n"+strings.Join(parts, "\n"), nil)
 				msg, err := a.userService.GetNews(ctx, settings)
 				if err == nil {
-					_, _ = a.tgClient.SendMessage(ctx, m.Chat.ID, msg, nil)
+					a.sendMessage(ctx, m.Chat.ID, msg, nil)
 				} else {
 					log.Println("get news:", err)
 				}
@@ -475,17 +489,17 @@ func (a *App) continueConversation(ctx context.Context, m *telegram.Message, c *
 		c.Stage = stageCategory
 		opts := addCustomOption(a.categoryOptions, c.AllowCustomCategory)
 		prompt := fmt.Sprintf("Выберите категорию №%d:\n%s\nВведите номер.", c.Step+1, formatOptions(opts))
-		msgID, _ := a.tgClient.SendMessage(ctx, m.Chat.ID, prompt, numberKeyboard(len(opts)))
+		msgID, _ := a.sendMessage(ctx, m.Chat.ID, prompt, numberKeyboard(len(opts)))
 		c.LastMsgID = msgID
 	case stageGetNewsCategory:
 		cats := parseSelection(m.Text, c.AvailableCats, 1)
 		if len(cats) == 0 {
-			msg, _ := a.tgClient.SendMessage(ctx, m.Chat.ID, "Выберите номер категории", numberKeyboard(len(c.AvailableCats)))
+			msg, _ := a.sendMessage(ctx, m.Chat.ID, "Выберите номер категории", numberKeyboard(len(c.AvailableCats)))
 			c.LastMsgID = msg
 			return
 		}
-		a.tgClient.DeleteMessage(ctx, m.Chat.ID, m.MessageID)
-		a.tgClient.DeleteMessage(ctx, m.Chat.ID, c.LastMsgID)
+		a.deleteMessage(ctx, m.Chat.ID, m.MessageID)
+		a.deleteMessage(ctx, m.Chat.ID, c.LastMsgID)
 		tariff, ok := a.cfg.Tariffs[c.Settings.Tariff]
 		if !ok {
 			tariff = a.cfg.Tariffs["base"]
@@ -496,7 +510,7 @@ func (a *App) continueConversation(ctx context.Context, m *telegram.Message, c *
 			c.Settings.GetNewsNowCount = 0
 		}
 		if c.Settings.GetNewsNowCount >= tariff.NumberGetNewsNowMessagesPerDay {
-			_, _ = a.tgClient.SendMessage(ctx, m.Chat.ID, "Лимит исчерпан на сегодня", nil)
+			a.sendMessage(ctx, m.Chat.ID, "Лимит исчерпан на сегодня", nil)
 			delete(a.convs, m.Chat.ID)
 			return
 		}
@@ -511,20 +525,20 @@ func (a *App) continueConversation(ctx context.Context, m *telegram.Message, c *
 			delete(a.convs, m.Chat.ID)
 			return
 		}
-		_, _ = a.tgClient.SendMessage(ctx, m.Chat.ID, msg, nil)
+		a.sendMessage(ctx, m.Chat.ID, msg, nil)
 		delete(a.convs, m.Chat.ID)
 
 	case stageGetLast24hCategory:
 		cats := parseSelection(m.Text, c.AvailableCats, 1)
 		if len(cats) == 0 {
-			msg, _ := a.tgClient.SendMessage(ctx, m.Chat.ID, "Выберите номер категории", numberKeyboard(len(c.AvailableCats)))
+			msg, _ := a.sendMessage(ctx, m.Chat.ID, "Выберите номер категории", numberKeyboard(len(c.AvailableCats)))
 			c.LastMsgID = msg
 			return
 		}
-		a.tgClient.DeleteMessage(ctx, m.Chat.ID, m.MessageID)
-		a.tgClient.DeleteMessage(ctx, m.Chat.ID, c.LastMsgID)
+		a.deleteMessage(ctx, m.Chat.ID, m.MessageID)
+		a.deleteMessage(ctx, m.Chat.ID, c.LastMsgID)
 
-		msgWait, _ := a.tgClient.SendMessage(ctx, m.Chat.ID, "Подождите, ищу информацию в интернете...", numberKeyboard(len(c.AvailableCats)))
+		msgWait, _ := a.sendMessage(ctx, m.Chat.ID, "Подождите, ищу информацию в интернете...", numberKeyboard(len(c.AvailableCats)))
 
 		msg, err := a.userService.GetLast24hNewsForCategory(ctx, c.Settings, cats[0])
 		if err != nil {
@@ -533,12 +547,9 @@ func (a *App) continueConversation(ctx context.Context, m *telegram.Message, c *
 			return
 		}
 
-		err = a.tgClient.DeleteMessage(ctx, m.Chat.ID, msgWait)
-		if err != nil {
-			log.Println("delete msg err: ", err)
-		}
+		a.deleteMessage(ctx, m.Chat.ID, msgWait)
 
-		_, err = a.tgClient.SendMessage(ctx, m.Chat.ID, msg, nil)
+		_, err = a.sendMessage(ctx, m.Chat.ID, msg, nil)
 		if err != nil {
 			log.Println("send msg err: ", err)
 		}
@@ -592,7 +603,7 @@ func (a *App) handleStartCommand(ctx context.Context, m *telegram.Message) {
 	if _, err := a.repo.Get(ctx, m.Chat.ID); err != nil {
 		conv := &conversationState{Stage: stageWelcome}
 		a.convs[m.Chat.ID] = conv
-		msgID, err := a.tgClient.SendMessage(ctx, m.Chat.ID, startMsg, [][]string{{"Продолжить"}})
+		msgID, err := a.sendMessage(ctx, m.Chat.ID, startMsg, [][]string{{"Продолжить"}})
 		if err != nil {
 			log.Printf("error when sending message to chat id %v: %v", m.Chat.ID, err)
 		}
@@ -602,7 +613,7 @@ func (a *App) handleStartCommand(ctx context.Context, m *telegram.Message) {
 	if err := a.userService.Start(ctx, m.Chat.ID, m.Chat.Username); err != nil {
 		log.Println("start:", err)
 	} else {
-		_, err := a.tgClient.SendMessage(ctx, m.Chat.ID, startMsg, nil)
+		_, err := a.sendMessage(ctx, m.Chat.ID, startMsg, nil)
 		if err != nil {
 			log.Printf("error when sending message to chat id %v: %v", m.Chat.ID, err)
 		}
@@ -614,7 +625,7 @@ func (a *App) handleStopCommand(ctx context.Context, m *telegram.Message) {
 	if err := a.userService.Stop(ctx, m.Chat.ID); err != nil {
 		log.Println("stop:", err)
 	} else {
-		_, _ = a.tgClient.SendMessage(ctx, m.Chat.ID, "Stopped updates", nil)
+		a.sendMessage(ctx, m.Chat.ID, "Stopped updates", nil)
 	}
 }
 
@@ -622,7 +633,7 @@ func (a *App) handleGetNewsNowCommand(ctx context.Context, m *telegram.Message) 
 	log.Printf("user %d(@%s) called /get_news_now", m.Chat.ID, m.Chat.Username)
 	settings, err := a.repo.Get(ctx, m.Chat.ID)
 	if err != nil {
-		a.tgClient.SendMessage(ctx, m.Chat.ID, "Use /start first", nil)
+		a.sendMessage(ctx, m.Chat.ID, "Use /start first", nil)
 		return
 	}
 	tariff, ok := a.cfg.Tariffs[settings.Tariff]
@@ -635,11 +646,11 @@ func (a *App) handleGetNewsNowCommand(ctx context.Context, m *telegram.Message) 
 		settings.GetNewsNowCount = 0
 	}
 	if settings.GetNewsNowCount >= tariff.NumberGetNewsNowMessagesPerDay {
-		_, _ = a.tgClient.SendMessage(ctx, m.Chat.ID, "Лимит исчерпан на сегодня", nil)
+		a.sendMessage(ctx, m.Chat.ID, "Лимит исчерпан на сегодня", nil)
 		return
 	}
 	if len(settings.Topics) == 0 {
-		_, _ = a.tgClient.SendMessage(ctx, m.Chat.ID, "Нет выбранных тем. Используйте /update_topics", nil)
+		a.sendMessage(ctx, m.Chat.ID, "Нет выбранных тем. Используйте /update_topics", nil)
 		return
 	}
 	conv := &conversationState{Stage: stageGetNewsCategory, Settings: settings}
@@ -649,7 +660,7 @@ func (a *App) handleGetNewsNowCommand(ctx context.Context, m *telegram.Message) 
 	}
 	a.convs[m.Chat.ID] = conv
 	prompt := fmt.Sprintf("Для какой категории получить информацию?\n%s\nВведите номер.", formatOptions(conv.AvailableCats))
-	msgID, _ := a.tgClient.SendMessage(ctx, m.Chat.ID, prompt, numberKeyboard(len(conv.AvailableCats)))
+	msgID, _ := a.sendMessage(ctx, m.Chat.ID, prompt, numberKeyboard(len(conv.AvailableCats)))
 	conv.LastMsgID = msgID
 }
 
@@ -657,15 +668,15 @@ func (a *App) handleGetLast24hNewsCommand(ctx context.Context, m *telegram.Messa
 	log.Printf("user %d(@%s) called /get_last_24h_news", m.Chat.ID, m.Chat.Username)
 	settings, err := a.repo.Get(ctx, m.Chat.ID)
 	if err != nil {
-		a.tgClient.SendMessage(ctx, m.Chat.ID, "Use /start first", nil)
+		a.sendMessage(ctx, m.Chat.ID, "Use /start first", nil)
 		return
 	}
 	if settings.Tariff != "plus" && settings.Tariff != "premium" && settings.Tariff != "ultimate" {
-		a.tgClient.SendMessage(ctx, m.Chat.ID, "Команда доступна на тарифах Plus и выше", nil)
+		a.sendMessage(ctx, m.Chat.ID, "Команда доступна на тарифах Plus и выше", nil)
 		return
 	}
 	if len(settings.Topics) == 0 {
-		_, _ = a.tgClient.SendMessage(ctx, m.Chat.ID, "Нет выбранных тем. Используйте /update_topics", nil)
+		a.sendMessage(ctx, m.Chat.ID, "Нет выбранных тем. Используйте /update_topics", nil)
 		return
 	}
 	conv := &conversationState{Stage: stageGetLast24hCategory, Settings: settings}
@@ -675,7 +686,7 @@ func (a *App) handleGetLast24hNewsCommand(ctx context.Context, m *telegram.Messa
 	}
 	a.convs[m.Chat.ID] = conv
 	prompt := fmt.Sprintf("Для какой категории получить новости за 24 часа?\n%s\nВведите номер.", formatOptions(conv.AvailableCats))
-	msgID, _ := a.tgClient.SendMessage(ctx, m.Chat.ID, prompt, numberKeyboard(len(conv.AvailableCats)))
+	msgID, _ := a.sendMessage(ctx, m.Chat.ID, prompt, numberKeyboard(len(conv.AvailableCats)))
 	conv.LastMsgID = msgID
 }
 
@@ -696,14 +707,14 @@ func (a *App) handleUpdateTopicsCommand(ctx context.Context, m *telegram.Message
 			conv.Topics[k] = append([]string(nil), v...)
 		}
 		a.convs[m.Chat.ID] = conv
-		msgID, _ := a.tgClient.SendMessage(ctx, m.Chat.ID, "Что будем обновлять?\n1. Обновить все\n2. Обновить одну", [][]string{{"1", "2"}})
+		msgID, _ := a.sendMessage(ctx, m.Chat.ID, "Что будем обновлять?\n1. Обновить все\n2. Обновить одну", [][]string{{"1", "2"}})
 		conv.LastMsgID = msgID
 		return
 	}
 	conv.Stage = stageCategory
 	a.convs[m.Chat.ID] = conv
 	prompt := fmt.Sprintf("Выберите категорию №1:\n%s\nВведите номер.", formatOptions(a.categoryOptions))
-	msgID, _ := a.tgClient.SendMessage(ctx, m.Chat.ID, prompt, numberKeyboard(len(a.categoryOptions)))
+	msgID, _ := a.sendMessage(ctx, m.Chat.ID, prompt, numberKeyboard(len(a.categoryOptions)))
 	conv.LastMsgID = msgID
 }
 
@@ -711,7 +722,7 @@ func (a *App) handleMyTopicsCommand(ctx context.Context, m *telegram.Message) {
 	log.Printf("user %d(@%s) called /my_topics", m.Chat.ID, m.Chat.Username)
 	settings, err := a.repo.Get(ctx, m.Chat.ID)
 	if err != nil {
-		_, _ = a.tgClient.SendMessage(ctx, m.Chat.ID, "Use /start first", nil)
+		a.sendMessage(ctx, m.Chat.ID, "Use /start first", nil)
 		return
 	}
 	parts := []string{}
@@ -719,5 +730,5 @@ func (a *App) handleMyTopicsCommand(ctx context.Context, m *telegram.Message) {
 		parts = append(parts, fmt.Sprintf("%s: %s", cat, strings.Join(types, ", ")))
 	}
 	msg := "Ваши темы:\n" + strings.Join(parts, "\n")
-	_, _ = a.tgClient.SendMessage(ctx, m.Chat.ID, msg, nil)
+	a.sendMessage(ctx, m.Chat.ID, msg, nil)
 }

--- a/pkg/openai/client.go
+++ b/pkg/openai/client.go
@@ -39,30 +39,16 @@ func (c *Client) do(ctx context.Context, endpoint string, body any, out any) err
 	}
 	req.Header.Set("Authorization", "Bearer "+c.token)
 	req.Header.Set("Content-Type", "application/json")
+
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return err
 	}
-	ba, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(ba, out)
-	if err != nil {
-		return err
-	}
-	return nil
-
-	fmt.Println(string(ba))
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return errors.New("openai: unexpected status " + resp.Status)
-	}
 
-	err = json.NewDecoder(resp.Body).Decode(out)
-	if err != nil {
-		return err
+	if resp.StatusCode != http.StatusOK {
+		data, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("openai: unexpected status %s: %s", resp.Status, string(data))
 	}
 
 	return json.NewDecoder(resp.Body).Decode(out)
@@ -139,7 +125,7 @@ func (c *Client) ChatResponses(ctx context.Context, model, prompt string) (strin
 	if err := c.do(ctx, "/responses", reqBody, &respBody); err != nil {
 		return "", err
 	}
-	if len(respBody.Output) == 0 {
+	if len(respBody.Output) < 2 || len(respBody.Output[1].Content) == 0 {
 		return "", errors.New("openai: empty response")
 	}
 


### PR DESCRIPTION
## Summary
- fix HTTP handling in `openai` client and validate response length
- add helper methods for sending and deleting Telegram messages with logs
- use helpers throughout the app for robust error logging

## Testing
- `go vet ./...` *(fails: proxy.golang.org blocked)*
- `go test ./...` *(fails: proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6883cd445cac832088494619978f065a