### PR TITLE
Implement /sett admin tariff command

### DIFF
--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -182,3 +182,28 @@ func (s *UserService) ActiveUsers(ctx context.Context) ([]*model.UserSettings, e
 	}
 	return out, nil
 }
+
+func (s *UserService) GetByUsername(ctx context.Context, username string) (*model.UserSettings, error) {
+	all, err := s.repo.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, u := range all {
+		if strings.EqualFold(u.UserName, username) {
+			return u, nil
+		}
+	}
+	return nil, os.ErrNotExist
+}
+
+func (s *UserService) SetTariff(ctx context.Context, userID int64, tariff string) error {
+	if _, ok := s.tariffs[tariff]; !ok {
+		return errors.New("unknown tariff")
+	}
+	u, err := s.repo.Get(ctx, userID)
+	if err != nil {
+		return err
+	}
+	u.Tariff = tariff
+	return s.repo.Save(ctx, u)
+}

--- a/internal/service/user_test.go
+++ b/internal/service/user_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/ilinovom/summary-tasks-bot/internal/config"
 	"github.com/ilinovom/summary-tasks-bot/internal/model"
 	"github.com/ilinovom/summary-tasks-bot/internal/repository"
 )
@@ -65,5 +66,24 @@ func TestUserService_StartStop(t *testing.T) {
 	u, _ = repo.Get(ctx, 1)
 	if u.Active {
 		t.Fatalf("expected inactive")
+	}
+}
+
+func TestUserService_GetByUsername_SetTariff(t *testing.T) {
+	repo := newMemRepo()
+	svc := NewUserService(repo, nil, map[string]config.Tariff{"base": {}, "plus": {}})
+	ctx := context.Background()
+
+	repo.Save(ctx, &model.UserSettings{UserID: 1, UserName: "user1"})
+	u, err := svc.GetByUsername(ctx, "user1")
+	if err != nil || u.UserID != 1 {
+		t.Fatalf("get by username failed: %v", err)
+	}
+	if err := svc.SetTariff(ctx, 1, "plus"); err != nil {
+		t.Fatalf("set tariff: %v", err)
+	}
+	u2, _ := repo.Get(ctx, 1)
+	if u2.Tariff != "plus" {
+		t.Fatalf("tariff not updated")
 	}
 }


### PR DESCRIPTION
## Summary
- add new conversation stages for admin tariff selection
- implement `/sett` command restricted to `@omilinov`
- add helper to update user tariff by username
- expose `GetByUsername` and `SetTariff` in user service
- cover new service logic with tests

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go build ./cmd/bot` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6884e2f3151083208b5b3cb914a51b67