### PR TITLE
Cycle news categories sequentially

### DIFF
--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -13,6 +13,24 @@ type UserSettings struct {
 	GetNewsNowCount   int                 `json:"get_news_now_count,omitempty"`
 	LastGetLast24h    int64               `json:"last_get_last_24h,omitempty"`
 	GetLast24hCount   int                 `json:"get_last_24h_count,omitempty"`
+	NextCategoryIndex int                 `json:"next_category_index,omitempty"`
+}
+
+// MessageSchedule stores scheduling data for a user.
+type MessageSchedule struct {
+	UserID            int64 `json:"user_id"`
+	Frequency         int   `json:"frequency,omitempty"`
+	LastScheduledSent int64 `json:"last_scheduled_sent,omitempty"`
+	NextCategoryIndex int   `json:"next_category_index,omitempty"`
+}
+
+// UserCommands stores command usage statistics for a user.
+type UserCommands struct {
+	UserID          int64 `json:"user_id"`
+	LastGetNewsNow  int64 `json:"last_get_news_now,omitempty"`
+	GetNewsNowCount int   `json:"get_news_now_count,omitempty"`
+	LastGetLast24h  int64 `json:"last_get_last_24h,omitempty"`
+	GetLast24hCount int   `json:"get_last_24h_count,omitempty"`
 }
 
 // Subscription represents a scheduled message subscription.

--- a/internal/repository/postgres_user_settings.go
+++ b/internal/repository/postgres_user_settings.go
@@ -29,42 +29,54 @@ func NewPostgresUserSettingsRepository(connStr string) (*PostgresUserSettingsRep
 	return r, nil
 }
 
-// init creates the user_settings table if it does not yet exist.
+// init creates necessary tables if they do not yet exist.
 func (r *PostgresUserSettingsRepository) init() error {
-	_, err := r.db.Exec(`
+	if _, err := r.db.Exec(`
         CREATE TABLE IF NOT EXISTS user_settings (
             user_id BIGINT PRIMARY KEY,
             username TEXT,
             active BOOLEAN,
             info_types JSONB,
             categories JSONB,
+            tariff TEXT
+        )`); err != nil {
+		return err
+	}
+	if _, err := r.db.Exec(`
+        CREATE TABLE IF NOT EXISTS message_schedule (
+            user_id BIGINT PRIMARY KEY REFERENCES user_settings(user_id),
             frequency INTEGER,
-            tariff TEXT,
-           last_scheduled_sent BIGINT,
-           last_get_news_now BIGINT,
+            last_scheduled_sent BIGINT,
+            next_category_index INTEGER
+        )`); err != nil {
+		return err
+	}
+	_, err := r.db.Exec(`
+        CREATE TABLE IF NOT EXISTS user_commands (
+            user_id BIGINT PRIMARY KEY REFERENCES user_settings(user_id),
+            last_get_news_now BIGINT,
             get_news_now_count INTEGER,
             last_get_last_24h BIGINT,
             get_last_24h_count INTEGER
         )`)
-	if err != nil {
-		return err
-	}
-	if _, err = r.db.Exec(`ALTER TABLE user_settings ADD COLUMN IF NOT EXISTS username TEXT`); err != nil {
-		return err
-	}
-	if _, err = r.db.Exec(`ALTER TABLE user_settings ADD COLUMN IF NOT EXISTS last_get_last_24h BIGINT`); err != nil {
-		return err
-	}
-	_, err = r.db.Exec(`ALTER TABLE user_settings ADD COLUMN IF NOT EXISTS get_last_24h_count INTEGER`)
 	return err
 }
 
 // Get retrieves a user's settings by ID.
 func (r *PostgresUserSettingsRepository) Get(ctx context.Context, userID int64) (*model.UserSettings, error) {
-	row := r.db.QueryRowContext(ctx, `SELECT user_id, username, active, info_types, categories, frequency, tariff, last_scheduled_sent, last_get_news_now, get_news_now_count, last_get_last_24h, get_last_24h_count FROM user_settings WHERE user_id=$1`, userID)
+	row := r.db.QueryRowContext(ctx, `
+        SELECT u.user_id, u.username, u.active, u.info_types, u.categories,
+               s.frequency, u.tariff, s.last_scheduled_sent,
+               c.last_get_news_now, c.get_news_now_count,
+               c.last_get_last_24h, c.get_last_24h_count,
+               s.next_category_index
+        FROM user_settings u
+        LEFT JOIN message_schedule s ON u.user_id = s.user_id
+        LEFT JOIN user_commands c ON u.user_id = c.user_id
+        WHERE u.user_id=$1`, userID)
 	var s model.UserSettings
 	var topics, categories []byte
-	if err := row.Scan(&s.UserID, &s.UserName, &s.Active, &topics, &categories, &s.Frequency, &s.Tariff, &s.LastScheduledSent, &s.LastGetNewsNow, &s.GetNewsNowCount, &s.LastGetLast24h, &s.GetLast24hCount); err != nil {
+	if err := row.Scan(&s.UserID, &s.UserName, &s.Active, &topics, &categories, &s.Frequency, &s.Tariff, &s.LastScheduledSent, &s.LastGetNewsNow, &s.GetNewsNowCount, &s.LastGetLast24h, &s.GetLast24hCount, &s.NextCategoryIndex); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, errors.New("not found")
 		}
@@ -88,34 +100,63 @@ func (r *PostgresUserSettingsRepository) Save(ctx context.Context, settings *mod
 	if err != nil {
 		return err
 	}
-	_, err = r.db.ExecContext(ctx, `
-        INSERT INTO user_settings (user_id, username, active, info_types, categories, frequency, tariff, last_scheduled_sent, last_get_news_now, get_news_now_count, last_get_last_24h, get_last_24h_count)
-        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+	if _, err := r.db.ExecContext(ctx, `
+        INSERT INTO user_settings (user_id, username, active, info_types, categories, tariff)
+        VALUES ($1,$2,$3,$4,$5,$6)
         ON CONFLICT (user_id) DO UPDATE SET
             username=EXCLUDED.username,
             active=EXCLUDED.active,
             info_types=EXCLUDED.info_types,
             categories=EXCLUDED.categories,
+            tariff=EXCLUDED.tariff
+        `, settings.UserID, settings.UserName, settings.Active, string(topics), string(categories), settings.Tariff); err != nil {
+		return err
+	}
+	if _, err := r.db.ExecContext(ctx, `
+        INSERT INTO message_schedule (user_id, frequency, last_scheduled_sent, next_category_index)
+        VALUES ($1,$2,$3,$4)
+        ON CONFLICT (user_id) DO UPDATE SET
             frequency=EXCLUDED.frequency,
-            tariff=EXCLUDED.tariff,
             last_scheduled_sent=EXCLUDED.last_scheduled_sent,
+            next_category_index=EXCLUDED.next_category_index
+        `, settings.UserID, settings.Frequency, settings.LastScheduledSent, settings.NextCategoryIndex); err != nil {
+		return err
+	}
+	_, err = r.db.ExecContext(ctx, `
+        INSERT INTO user_commands (user_id, last_get_news_now, get_news_now_count, last_get_last_24h, get_last_24h_count)
+        VALUES ($1,$2,$3,$4,$5)
+        ON CONFLICT (user_id) DO UPDATE SET
             last_get_news_now=EXCLUDED.last_get_news_now,
             get_news_now_count=EXCLUDED.get_news_now_count,
             last_get_last_24h=EXCLUDED.last_get_last_24h,
             get_last_24h_count=EXCLUDED.get_last_24h_count
-   `, settings.UserID, settings.UserName, settings.Active, string(topics), string(categories), settings.Frequency, settings.Tariff, settings.LastScheduledSent, settings.LastGetNewsNow, settings.GetNewsNowCount, settings.LastGetLast24h, settings.GetLast24hCount)
+        `, settings.UserID, settings.LastGetNewsNow, settings.GetNewsNowCount, settings.LastGetLast24h, settings.GetLast24hCount)
 	return err
 }
 
 // Delete removes settings for a user.
 func (r *PostgresUserSettingsRepository) Delete(ctx context.Context, userID int64) error {
+	if _, err := r.db.ExecContext(ctx, `DELETE FROM message_schedule WHERE user_id=$1`, userID); err != nil {
+		return err
+	}
+	if _, err := r.db.ExecContext(ctx, `DELETE FROM user_commands WHERE user_id=$1`, userID); err != nil {
+		return err
+	}
 	_, err := r.db.ExecContext(ctx, `DELETE FROM user_settings WHERE user_id=$1`, userID)
 	return err
 }
 
 // List returns settings for all users.
 func (r *PostgresUserSettingsRepository) List(ctx context.Context) ([]*model.UserSettings, error) {
-	rows, err := r.db.QueryContext(ctx, `SELECT user_id, username, active, info_types, categories, frequency, tariff, last_scheduled_sent, last_get_news_now, get_news_now_count, last_get_last_24h, get_last_24h_count FROM user_settings`)
+	rows, err := r.db.QueryContext(ctx, `
+        SELECT u.user_id, u.username, u.active, u.info_types, u.categories,
+               s.frequency, u.tariff, s.last_scheduled_sent,
+               c.last_get_news_now, c.get_news_now_count,
+               c.last_get_last_24h, c.get_last_24h_count,
+               s.next_category_index
+        FROM user_settings u
+        LEFT JOIN message_schedule s ON u.user_id = s.user_id
+        LEFT JOIN user_commands c ON u.user_id = c.user_id`)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +165,7 @@ func (r *PostgresUserSettingsRepository) List(ctx context.Context) ([]*model.Use
 	for rows.Next() {
 		var s model.UserSettings
 		var topics, categories []byte
-		if err := rows.Scan(&s.UserID, &s.UserName, &s.Active, &topics, &categories, &s.Frequency, &s.Tariff, &s.LastScheduledSent, &s.LastGetNewsNow, &s.GetNewsNowCount, &s.LastGetLast24h, &s.GetLast24hCount); err != nil {
+		if err := rows.Scan(&s.UserID, &s.UserName, &s.Active, &topics, &categories, &s.Frequency, &s.Tariff, &s.LastScheduledSent, &s.LastGetNewsNow, &s.GetNewsNowCount, &s.LastGetLast24h, &s.GetLast24hCount, &s.NextCategoryIndex); err != nil {
 			return nil, err
 		}
 		json.Unmarshal(topics, &s.Topics)

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"math/rand"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/ilinovom/summary-tasks-bot/internal/config"
@@ -104,7 +105,7 @@ func (s *UserService) GetNews(ctx context.Context, u *model.UserSettings) (strin
 	return prefix + resp, nil
 }
 
-// GetNewsMultiInfo returns news for one random category with all selected info types.
+// GetNewsMultiInfo returns news cycling through categories sequentially with all selected info types.
 func (s *UserService) GetNewsMultiInfo(ctx context.Context, u *model.UserSettings) (string, error) {
 	if len(u.Topics) == 0 {
 		return "", errors.New("no topics")
@@ -113,7 +114,13 @@ func (s *UserService) GetNewsMultiInfo(ctx context.Context, u *model.UserSetting
 	for c := range u.Topics {
 		cats = append(cats, c)
 	}
-	category := cats[rand.Intn(len(cats))]
+	sort.Strings(cats)
+	idx := u.NextCategoryIndex % len(cats)
+	category := cats[idx]
+	u.NextCategoryIndex = (idx + 1) % len(cats)
+	if err := s.repo.Save(ctx, u); err != nil {
+		return "", err
+	}
 	infos := u.Topics[category]
 	t, ok := s.tariffs[u.Tariff]
 	if !ok {

--- a/migrations/004_add_next_category_index.sql
+++ b/migrations/004_add_next_category_index.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_settings
+    ADD COLUMN IF NOT EXISTS next_category_index INTEGER;

--- a/migrations/005_split_user_tables.sql
+++ b/migrations/005_split_user_tables.sql
@@ -1,0 +1,23 @@
+ALTER TABLE user_settings
+    DROP COLUMN IF EXISTS frequency,
+    DROP COLUMN IF EXISTS last_scheduled_sent,
+    DROP COLUMN IF EXISTS next_category_index,
+    DROP COLUMN IF EXISTS last_get_news_now,
+    DROP COLUMN IF EXISTS get_news_now_count,
+    DROP COLUMN IF EXISTS last_get_last_24h,
+    DROP COLUMN IF EXISTS get_last_24h_count;
+
+CREATE TABLE IF NOT EXISTS message_schedule (
+    user_id BIGINT PRIMARY KEY REFERENCES user_settings (user_id),
+    frequency INTEGER,
+    last_scheduled_sent BIGINT,
+    next_category_index INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS user_commands (
+    user_id BIGINT PRIMARY KEY REFERENCES user_settings (user_id),
+    last_get_news_now BIGINT,
+    get_news_now_count INTEGER,
+    last_get_last_24h BIGINT,
+    get_last_24h_count INTEGER
+);


### PR DESCRIPTION
## Summary
- Rotate through user categories sequentially in `GetNewsMultiInfo`
- Track and persist category position with new `NextCategoryIndex` field
- Split user data into separate `message_schedule` and `user_commands` tables with migration and repository support

## Testing
- `go test -v ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897433302f4832087be537dbffba64b